### PR TITLE
Updating Bake to BakeAsync

### DIFF
--- a/PrefabLightmapData.cs
+++ b/PrefabLightmapData.cs
@@ -166,7 +166,7 @@ public class PrefabLightmapData : MonoBehaviour
             Debug.LogError("ExtractLightmapData requires that you have baked you lightmaps and Auto mode is disabled.");
             return;
         }
-        UnityEditor.Lightmapping.Bake();
+        UnityEditor.Lightmapping.BakeAsync();
 
         PrefabLightmapData[] prefabs = FindObjectsOfType<PrefabLightmapData>();
 


### PR DESCRIPTION
- Bake function freezes Unity and does not show any progress of the bake task.
- BakeAsync function will not freeze unity and show baking progress at the bottom right.